### PR TITLE
Changed node-sass version to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "framer-motion": "4.1.17",
     "match-sorter": "6.3.0",
     "moment": "2.29.1",
-    "node-sass": "5.0.0",
+    "node-sass": "6.0.0",
     "nodemon": "^2.0.15",
     "nouislider": "15.0.0",
     "react": "^16.14.0",


### PR DESCRIPTION
Hi Rise 
I was facing error due to node-sass version, I was using node version 16 and previous sass version was not compatible thus changed the sass version to 6.0.0